### PR TITLE
feat: Add like button to entries

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run: deno fmt --check
       - run: deno lint
-      - run: deno test -A --coverage=coverage
+      - run: deno test -A --unstable-kv --coverage=coverage
       - run: deno coverage ./coverage --lcov > coverage.lcov
 
       - name: Upload coverage reports to Codecov

--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,17 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": true,
   "tasks": {
     "start": "deno run -A --unstable-kv --watch=static/,routes/,islands/ dev.ts",
     "build": "deno run -A dev.ts build",
     "lint": "deno run -A npm:textlint",
     "preview": "deno run -A main.ts"
+  },
+  "fmt": {
+    "exclude": [
+      "static/",
+      "posts/"
+    ]
   },
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/deno.json
+++ b/deno.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
-  "nodeModulesDir": true,
+  "nodeModulesDir": "auto",
   "tasks": {
-    "start": "deno run -A --watch=static/,routes/ dev.ts",
+    "start": "deno run -A --unstable-kv --watch=static/,routes/,islands/ dev.ts",
     "build": "deno run -A dev.ts build",
     "lint": "deno run -A npm:textlint",
     "preview": "deno run -A main.ts"

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
   "nodeModulesDir": true,
   "tasks": {
     "start": "deno run -A --unstable-kv --watch=static/,routes/,islands/ dev.ts",
-    "build": "deno run -A dev.ts build",
+    "build": "deno run -A --unstable-kv dev.ts build",
     "lint": "deno run -A npm:textlint",
     "preview": "deno run -A main.ts"
   },

--- a/deno.json
+++ b/deno.json
@@ -37,9 +37,15 @@
   },
   "lint": {
     "rules": {
-      "tags": ["fresh", "recommended"]
+      "tags": [
+        "fresh",
+        "recommended"
+      ]
     }
   },
-  "exclude": ["**/_fresh/*", "cache"],
+  "exclude": [
+    "**/_fresh/*",
+    "cache"
+  ],
   "lock": false
 }

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -6,10 +6,12 @@ import * as $_404 from "./routes/_404.tsx";
 import * as $_app from "./routes/_app.tsx";
 import * as $_middleware from "./routes/_middleware.ts";
 import * as $about_index from "./routes/about/index.tsx";
+import * as $api_likes from "./routes/api/likes.ts";
 import * as $entry_all_ from "./routes/entry/[...all].tsx";
 import * as $healthz from "./routes/healthz.tsx";
 import * as $index from "./routes/index.tsx";
 import * as $rss_xml from "./routes/rss.xml.ts";
+import * as $LikeButton from "./islands/LikeButton.tsx";
 import * as $SearchButton from "./islands/SearchButton.tsx";
 import type { Manifest } from "$fresh/server.ts";
 
@@ -19,12 +21,14 @@ const manifest = {
     "./routes/_app.tsx": $_app,
     "./routes/_middleware.ts": $_middleware,
     "./routes/about/index.tsx": $about_index,
+    "./routes/api/likes.ts": $api_likes,
     "./routes/entry/[...all].tsx": $entry_all_,
     "./routes/healthz.tsx": $healthz,
     "./routes/index.tsx": $index,
     "./routes/rss.xml.ts": $rss_xml,
   },
   islands: {
+    "./islands/LikeButton.tsx": $LikeButton,
     "./islands/SearchButton.tsx": $SearchButton,
   },
   baseUrl: import.meta.url,

--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+
+interface LikeButtonProps {
+  slug: string;
+}
+
+export default function LikeButton({ slug }: LikeButtonProps) {
+  const likeCount = useSignal(0);
+  const [isLiked, setIsLiked] = useState(false);
+
+  useEffect(() => {
+    const fetchLikes = async () => {
+      const res = await fetch(`/api/likes?slug=${slug}`);
+      if (res.ok) {
+        const { count } = await res.json();
+        likeCount.value = count;
+      }
+    };
+    fetchLikes();
+
+    const likedInStorage = localStorage.getItem(`liked-${slug}`);
+    if (likedInStorage === "true") {
+      setIsLiked(true);
+    }
+  }, [slug]);
+
+  const handleClick = async () => {
+    const action = isLiked ? "unlike" : "like";
+    const res = await fetch("/api/likes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug, action }),
+    });
+
+    if (res.ok) {
+      if (action === "like") {
+        likeCount.value++;
+        setIsLiked(true);
+        localStorage.setItem(`liked-${slug}`, "true");
+      } else {
+        likeCount.value--;
+        setIsLiked(false);
+        localStorage.setItem(`liked-${slug}`, "false");
+      }
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      class={`px-4 py-2 font-bold text-white rounded ${
+        isLiked
+          ? "bg-red-500 hover:bg-red-700"
+          : "bg-blue-500 hover:bg-blue-700"
+      }`}
+    >
+      👍 {likeCount} Likes
+    </button>
+  );
+}

--- a/posts/2012/09/11/octpress-install-and-setup.md
+++ b/posts/2012/09/11/octpress-install-and-setup.md
@@ -1,7 +1,7 @@
 ---
-title: 'octpress install and setup'
-date: '2012-09-11'
-permalink: '/entry/2012/09/11/octpress-install-and-setup/'
+title: "octpress install and setup"
+date: "2012-09-11"
+permalink: "/entry/2012/09/11/octpress-install-and-setup/"
 ---
 
 # octpress試す

--- a/posts/2012/09/13/python-install.md
+++ b/posts/2012/09/13/python-install.md
@@ -1,8 +1,8 @@
 ---
-title: 'python install'
-date: '2012-09-13'
-permalink: '/entry/2012/09/13/python-install/'
-category: 'python'
+title: "python install"
+date: "2012-09-13"
+permalink: "/entry/2012/09/13/python-install/"
+category: "python"
 ---
 
 # first Python

--- a/posts/2012/11/24/developer-festa.md
+++ b/posts/2012/11/24/developer-festa.md
@@ -1,9 +1,9 @@
 ---
-title: 'Python Developer Festa 参加してきました'
-date: '2012-11-24'
-permalink: '/entry/2012/11/24/developer-festa/'
+title: "Python Developer Festa 参加してきました"
+date: "2012-11-24"
+permalink: "/entry/2012/11/24/developer-festa/"
 categories:
-  - 'python'
+  - "python"
 ---
 
 # Python Developer Festa 参加してきたので、そのメモ

--- a/posts/2012/12/20/elixir-install.md
+++ b/posts/2012/12/20/elixir-install.md
@@ -1,8 +1,8 @@
 ---
-title: 'elixir install'
-date: '2012-12-20'
-permalink: '/entry/2012/12/20/elixir-install/'
-category: 'elixir'
+title: "elixir install"
+date: "2012-12-20"
+permalink: "/entry/2012/12/20/elixir-install/"
+category: "elixir"
 ---
 
 # Elixirはじめよう

--- a/posts/2013/02/03/readable-code.md
+++ b/posts/2013/02/03/readable-code.md
@@ -1,8 +1,8 @@
 ---
-title: 'リーダブルコード読みました'
-date: '2013-02-03'
-permalink: '/entry/2013/02/03/readable-code/'
-category: 'book'
+title: "リーダブルコード読みました"
+date: "2013-02-03"
+permalink: "/entry/2013/02/03/readable-code/"
+category: "book"
 ---
 
 # リーダーブルコードよんだメモ

--- a/posts/2013/03/02/riak-meetoup-tokyo.md
+++ b/posts/2013/03/02/riak-meetoup-tokyo.md
@@ -1,9 +1,9 @@
 ---
-title: 'riak meetup tokyoに参加してきました'
-date: '2013-03-12'
-permalink: '/entry/2013/03/02/riak-meetoup-tokyo/'
+title: "riak meetup tokyoに参加してきました"
+date: "2013-03-12"
+permalink: "/entry/2013/03/02/riak-meetoup-tokyo/"
 categories:
-  - 'erlang'
+  - "erlang"
 ---
 
 # Riak intro & RICON 報告

--- a/posts/2013/03/06/developer-festa.md
+++ b/posts/2013/03/06/developer-festa.md
@@ -1,9 +1,9 @@
 ---
-title: 'pyfes 2013/3'
-date: '2013-03-16'
-permalink: '/entry/2013/03/06/developer-festa/'
+title: "pyfes 2013/3"
+date: "2013-03-16"
+permalink: "/entry/2013/03/06/developer-festa/"
 categories:
-  - 'python'
+  - "python"
 ---
 
 # TL;DR

--- a/posts/2013/04/13/gocon.md
+++ b/posts/2013/04/13/gocon.md
@@ -1,9 +1,9 @@
 ---
-title: 'Go Conference 2013 spring参加してきました #gocon'
-date: '2013-04-13'
-permalink: '/entry/2013/04/13/gocon/'
+title: "Go Conference 2013 spring参加してきました #gocon"
+date: "2013-04-13"
+permalink: "/entry/2013/04/13/gocon/"
 categories:
-  - 'go'
+  - "go"
 ---
 
 # Go Conference 参加メモ

--- a/posts/2013/07/10/riak-meetup-tokyo.md
+++ b/posts/2013/07/10/riak-meetup-tokyo.md
@@ -1,9 +1,9 @@
 ---
-title: 'riak meetup tokyo 2 に参加してきました'
-date: '2013-07-10'
-permalink: '/entry/2013/07/10/riak-meetup-tokyo/'
+title: "riak meetup tokyo 2 に参加してきました"
+date: "2013-07-10"
+permalink: "/entry/2013/07/10/riak-meetup-tokyo/"
 categories:
-  - 'erlang'
+  - "erlang"
 ---
 
 # riak meetup tokyo 2 memo

--- a/posts/2013/11/13/plantuml.md
+++ b/posts/2013/11/13/plantuml.md
@@ -1,7 +1,7 @@
 ---
-title: 'クラス図を簡単に - PlantUML'
-date: '2013-11-13'
-permalink: '/entry/2013/11/13/escape-ime/'
+title: "クラス図を簡単に - PlantUML"
+date: "2013-11-13"
+permalink: "/entry/2013/11/13/escape-ime/"
 ---
 
 # PlantUML

--- a/posts/2013/12/22/my-first-chef.md
+++ b/posts/2013/12/22/my-first-chef.md
@@ -1,10 +1,10 @@
 ---
-title: '入門chef'
-date: '2013-12-22'
-permalink: '/entry/2013/12/22/my-first-chef/'
+title: "入門chef"
+date: "2013-12-22"
+permalink: "/entry/2013/12/22/my-first-chef/"
 categories:
-  - 'ruby'
-  - 'chef'
+  - "ruby"
+  - "chef"
 ---
 
 # chef memo

--- a/posts/2013/12/25/agile-samurai.md
+++ b/posts/2013/12/25/agile-samurai.md
@@ -1,9 +1,9 @@
 ---
-title: '読書 アジャイルサムライ'
-date: '2013-12-25'
-permalink: '/entry/2013/12/25/agile-samurai/'
+title: "読書 アジャイルサムライ"
+date: "2013-12-25"
+permalink: "/entry/2013/12/25/agile-samurai/"
 categories:
-  - 'book'
+  - "book"
 ---
 
 # メモ

--- a/posts/2013/12/25/team-geak.md
+++ b/posts/2013/12/25/team-geak.md
@@ -1,8 +1,8 @@
 ---
-title: '読書 Team Geek'
-date: '2013-12-25'
-permalink: '/entry/2013/12/25/team-geak/'
-category: 'book'
+title: "読書 Team Geek"
+date: "2013-12-25"
+permalink: "/entry/2013/12/25/team-geak/"
+category: "book"
 ---
 
 # メモ

--- a/routes/api/likes.ts
+++ b/routes/api/likes.ts
@@ -1,0 +1,34 @@
+import type { Handlers } from "$fresh/server.ts";
+
+const kv = await Deno.openKv();
+
+export const handler: Handlers = {
+  async GET(req) {
+    const slug = new URL(req.url).searchParams.get("slug");
+    if (!slug) {
+      return new Response("slug is required", { status: 400 });
+    }
+    const count = (await kv.get(["likes", slug])).value as number ?? 0;
+    return new Response(JSON.stringify({ count }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  },
+
+  async POST(req) {
+    const { slug, action } = await req.json();
+    if (!slug) {
+      return new Response("slug is required", { status: 400 });
+    }
+
+    const value = action === "like" ? 1n : -1n;
+
+    await kv.atomic()
+      .mutate({
+        type: "sum",
+        key: ["likes", slug],
+        value: new Deno.KvU64(value),
+      })
+      .commit();
+    return new Response("ok");
+  },
+};

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -1,6 +1,7 @@
 import { Head } from "$fresh/runtime.ts";
 import type { Handlers, PageProps } from "$fresh/server.ts";
 import { SEO } from "@/components/SEO.tsx";
+import LikeButton from "@/islands/LikeButton.tsx";
 import { getPost, type Post } from "@/utils/posts.ts";
 import { description, title } from "@/utils/website.ts";
 import { CSS, render } from "@deno/gfm";
@@ -30,6 +31,7 @@ export default function PostPage(props: PageProps<Post>) {
       </Head>
       <main class="flex-grow max-w-screen-md w-full px-4 pt-4 mx-auto">
         <h1 class="text-2xl font-bold">{post.title}</h1>
+        <LikeButton slug={post.slug} />
         <div class="grid grid-cols-2 gap-4">
           <time class="text-gray-500">
             {new Date(post.publishedAt).toLocaleDateString("en-us", {


### PR DESCRIPTION
This commit introduces a 'Like' button feature for each blog entry.

- A new API route `routes/api/likes.ts` has been created to handle like and unlike actions. It uses Deno KV to store and retrieve the like counts for each post.
- A new Fresh island component `islands/LikeButton.tsx` has been created to provide an interactive UI for liking and unliking posts. It uses `localStorage` to track the user's liked state for each post.
- The `LikeButton` component has been integrated into the main post page at `routes/entry/[...all].tsx`.
- The `deno.json` file has been updated to enable Deno KV and to watch the `islands` directory for changes.