### PR TITLE
fix: Add --unstable-kv flag to build task

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
   "nodeModulesDir": true,
   "tasks": {
     "start": "deno run -A --unstable-kv --watch=static/,routes/,islands/ dev.ts",
-    "build": "deno run -A dev.ts build",
+    "build": "deno run -A --unstable-kv dev.ts build",
     "lint": "deno run -A npm:textlint",
     "preview": "deno run -A main.ts"
   },


### PR DESCRIPTION
The `deno task build` command was failing in the CI/CD pipeline because it was attempting to access Deno KV features without the necessary permissions. The `routes/api/likes.ts` file uses `Deno.openKv()`, which requires the `--unstable-kv` flag to be present during execution.

This commit adds the `--unstable-kv` flag to the `build` task in `deno.json` to ensure that Deno KV is enabled during the build process, resolving the deployment failure.