### PR TITLE
feat: サイドバーにLikeボタンを設置

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,3 @@
+[0m[38;5;12mWatcher[0m Process started.
+[0m[33mWarning[0m `"nodeModulesDir": true` is deprecated in Deno 2.0. Use `"nodeModulesDir": "auto"` instead.
+    at file:///app/deno.json

--- a/dev.log
+++ b/dev.log
@@ -1,3 +1,0 @@
-[0m[38;5;12mWatcher[0m Process started.
-[0m[33mWarning[0m `"nodeModulesDir": true` is deprecated in Deno 2.0. Use `"nodeModulesDir": "auto"` instead.
-    at file:///app/deno.json

--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -47,29 +47,31 @@ export default function LikeButton({ slug }: LikeButtonProps) {
   };
 
   return (
-    <button
-      onClick={handleClick}
-      class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${
-        isLiked
-          ? "bg-red-100 text-red-500"
-          : "bg-gray-100 text-gray-500 hover:bg-gray-200"
-      }`}
-      aria-label="Like this post"
-    >
-      <svg
-        class="w-6 h-6"
-        fill="currentColor"
-        viewBox="0 0 20 20"
-        xmlns="http://www.w3.org/2000/svg"
+    <div class="flex flex-col items-center">
+      <button
+        onClick={handleClick}
+        class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${
+          isLiked
+            ? "bg-red-100 text-red-500"
+            : "bg-gray-100 text-gray-500 hover:bg-gray-200"
+        }`}
+        aria-label="Like this post"
       >
-        <path
-          fill-rule="evenodd"
-          d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
-          clip-rule="evenodd"
+        <svg
+          class="w-6 h-6"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
         >
-        </path>
-      </svg>
-      <span class="ml-2">{likeCount}</span>
-    </button>
+          <path
+            fill-rule="evenodd"
+            d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </button>
+      <span class="mt-2 text-sm text-gray-500">{likeCount}</span>
+    </div>
   );
 }

--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -49,13 +49,27 @@ export default function LikeButton({ slug }: LikeButtonProps) {
   return (
     <button
       onClick={handleClick}
-      class={`px-4 py-2 font-bold text-white rounded ${
+      class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${
         isLiked
-          ? "bg-red-500 hover:bg-red-700"
-          : "bg-blue-500 hover:bg-blue-700"
+          ? "bg-red-100 text-red-500"
+          : "bg-gray-100 text-gray-500 hover:bg-gray-200"
       }`}
+      aria-label="Like this post"
     >
-      👍 {likeCount} Likes
+      <svg
+        class="w-6 h-6"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+      <span class="ml-2">{likeCount}</span>
     </button>
   );
 }

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -31,12 +31,12 @@ export default function PostPage(props: PageProps<Post>) {
       </Head>
       <div class="flex-grow max-w-screen-lg mx-auto w-full">
         <div class="flex flex-row">
-          <div class="w-1/4 py-8">
+          <div class="w-20 py-8">
             <div class="sticky top-20">
               <LikeButton slug={post.slug} />
             </div>
           </div>
-          <main class="w-3/4">
+          <main class="w-full">
             <h1 class="text-2xl font-bold">{post.title}</h1>
             <div class="grid grid-cols-2 gap-4">
               <time class="text-gray-500">

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -32,7 +32,7 @@ export default function PostPage(props: PageProps<Post>) {
       <div class="flex-grow max-w-screen-lg mx-auto w-full">
         <div class="flex flex-row">
           <div class="w-20 py-8">
-            <div class="sticky top-20">
+            <div class="sticky">
               <LikeButton slug={post.slug} />
             </div>
           </div>

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -29,24 +29,32 @@ export default function PostPage(props: PageProps<Post>) {
         />
         <style dangerouslySetInnerHTML={{ __html: CSS }} />
       </Head>
-      <main class="flex-grow max-w-screen-md w-full px-4 pt-4 mx-auto">
-        <h1 class="text-2xl font-bold">{post.title}</h1>
-        <LikeButton slug={post.slug} />
-        <div class="grid grid-cols-2 gap-4">
-          <time class="text-gray-500">
-            {new Date(post.publishedAt).toLocaleDateString("en-us", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
-          </time>
-          <p class="text-gray-500">Number of word {post.content.length}</p>
+      <div class="flex-grow max-w-screen-lg mx-auto w-full">
+        <div class="flex flex-row">
+          <div class="w-1/4 py-8">
+            <div class="sticky top-20">
+              <LikeButton slug={post.slug} />
+            </div>
+          </div>
+          <main class="w-3/4">
+            <h1 class="text-2xl font-bold">{post.title}</h1>
+            <div class="grid grid-cols-2 gap-4">
+              <time class="text-gray-500">
+                {new Date(post.publishedAt).toLocaleDateString("en-us", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+              <p class="text-gray-500">Number of word {post.content.length}</p>
+            </div>
+            <div
+              class="mt-8 markdown-body"
+              dangerouslySetInnerHTML={{ __html: render(post.content) }}
+            />
+          </main>
         </div>
-        <div
-          class="mt-8 markdown-body"
-          dangerouslySetInnerHTML={{ __html: render(post.content) }}
-        />
-      </main>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
dev.to の記事ページを参考にLikeボタンをサイドバーに設置するように変更しました。
また、ボタンのスタイルもdev.toに似せて変更しました。

- `routes/entry/[...all].tsx` のレイアウトを2カラムに変更
- `LikeButton` をサイドバーに移動
- `LikeButton` のスタイルをアイコンとカウント表示に変更