### PR TITLE
feat: 中央寄せレイアウトに調整

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -13,7 +13,7 @@ export function Footer() {
   ];
 
   return (
-    <footer class="w-full border-t">
+    <footer class="w-full">
       <div class="max-w-screen-lg w-full mx-auto flex flex-col md:flex-row gap-8 md:gap-16 px-4 py-8 text-sm">
         <div class="flex-1">
           <div class="flex items-center gap-1">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -13,43 +13,48 @@ export function Footer() {
   ];
 
   return (
-    <footer class="flex flex-col md:flex-row w-full gap-8 md:gap-16 px-4 py-8 text-sm">
-      <div class="flex-1">
-        <div class="flex items-center gap-1">
-          <Campfire class="inline-block" />
-          <div class="font-bold text-2xl">{author}</div>
-        </div>
-        <div class="text-gray-500">Lazy builder</div>
-      </div>
-
-      {menus.map((item) => (
-        <div class="mb-4" key={item.title}>
-          <div class="font-bold">{item.title}</div>
-          <ul class="mt-2">
-            {item.children.map((child) => (
-              <li class="mt-2" key={child.name}>
-                <a class="text-gray-500 hover:text-gray-700" href={child.href}>
-                  {child.name}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
-
-      <div class="text-gray-500 space-y-2">
-        <div class="text-xs">
-          Copyright © {new Date().getFullYear()} github.com/9renpoto
-          <br />
-          All right reserved.
+    <footer class="w-full border-t">
+      <div class="max-w-screen-lg w-full mx-auto flex flex-col md:flex-row gap-8 md:gap-16 px-4 py-8 text-sm">
+        <div class="flex-1">
+          <div class="flex items-center gap-1">
+            <Campfire class="inline-block" />
+            <div class="font-bold text-2xl">{author}</div>
+          </div>
+          <div class="text-gray-500">Lazy builder</div>
         </div>
 
-        <a
-          href="https://github.com/9renpoto/win"
-          class="inline-block hover:text-black"
-        >
-          <BrandGithub />
-        </a>
+        {menus.map((item) => (
+          <div class="mb-4" key={item.title}>
+            <div class="font-bold">{item.title}</div>
+            <ul class="mt-2">
+              {item.children.map((child) => (
+                <li class="mt-2" key={child.name}>
+                  <a
+                    class="text-gray-500 hover:text-gray-700"
+                    href={child.href}
+                  >
+                    {child.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+
+        <div class="text-gray-500 space-y-2">
+          <div class="text-xs">
+            Copyright © {new Date().getFullYear()} github.com/9renpoto
+            <br />
+            All right reserved.
+          </div>
+
+          <a
+            href="https://github.com/9renpoto/win"
+            class="inline-block hover:text-black"
+          >
+            <BrandGithub />
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,25 +9,27 @@ export function Header({ title }: { title: string }) {
     { name: <>About me</>, href: "/about" },
   ];
   return (
-    <header class="w-full py-6 px-4 flex flex-col md:flex-row gap-4">
-      <div class="flex items-center flex-1">
-        <Campfire />
-        <a href="/">
-          <div class="text-2xl ml-1 font-bold">{title}</div>
-        </a>
+    <header class="w-full border-b">
+      <div class="max-w-screen-lg w-full mx-auto py-6 px-4 flex flex-col md:flex-row gap-4">
+        <div class="flex items-center flex-1">
+          <Campfire />
+          <a href="/">
+            <div class="text-2xl ml-1 font-bold">{title}</div>
+          </a>
+        </div>
+        <ul class="flex items-center gap-6">
+          {menus.map((menu) => (
+            <li>
+              <a
+                href={menu.href}
+                class={"text-gray-500 hover:text-gray-700 py-1 border-gray-500"}
+              >
+                {menu.name}
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
-      <ul class="flex items-center gap-6">
-        {menus.map((menu) => (
-          <li>
-            <a
-              href={menu.href}
-              class={"text-gray-500 hover:text-gray-700 py-1 border-gray-500"}
-            >
-              {menu.name}
-            </a>
-          </li>
-        ))}
-      </ul>
     </header>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,7 +9,7 @@ export function Header({ title }: { title: string }) {
     { name: <>About me</>, href: "/about" },
   ];
   return (
-    <header class="w-full border-b">
+    <header class="w-full">
       <div class="max-w-screen-lg w-full mx-auto py-6 px-4 flex flex-col md:flex-row gap-4">
         <div class="flex items-center flex-1">
           <Campfire />

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -2,6 +2,6 @@ import type { UnknownPageProps } from "$fresh/server.ts";
 
 export default function NotFoundPage({ url }: UnknownPageProps) {
   return (
-    <p class="max-w-screen-md w-full px-4 pt-16 mx-auto">404 not found {url}</p>
+    <p class="max-w-screen-lg w-full px-4 pt-16 mx-auto">404 not found {url}</p>
   );
 }

--- a/routes/about/index.tsx
+++ b/routes/about/index.tsx
@@ -25,7 +25,7 @@ export default function AboutPage(props: PageProps<Post>) {
         />
         <style dangerouslySetInnerHTML={{ __html: CSS }} />
       </Head>
-      <main class="flex-grow max-w-screen-md w-full px-4 pt-4 mx-auto">
+      <main class="flex-grow max-w-screen-lg w-full px-4 pt-4 mx-auto">
         <h1 class="text-2xl font-bold">{post.title}</h1>
         <time class="text-gray-500">
           {new Date(post.publishedAt).toLocaleDateString("en-us", {

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -23,7 +23,7 @@ export default function BlogIndexPage({ data: posts }: PageProps<Post[]>) {
           ogImage="https://avatars3.githubusercontent.com/u/520693?s=460&v=4"
         />
       </Head>
-      <main class="max-w-screen-md w-full px-4 pt-4 mx-auto">
+      <main class="max-w-screen-lg w-full px-4 pt-4 mx-auto">
         <Bio author={author} />
         <div class="mt-8">
           {posts.map((post, i) => (


### PR DESCRIPTION
zenn.dev を参考に、サイト全体のレイアウトを中央寄せに統一しました。

- Header と Footer のコンテンツを `max-w-screen-lg` のコンテナでラップし、中央に配置しました。
- ホームページ、アバウトページ、404ページのメインコンテンツの幅も `max-w-screen-lg` に統一し、サイト全体で一貫性のあるレイアウトを実現しました。