### PR TITLE
feat: Make Like button fixed on mobile

### DIFF
--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -47,7 +47,9 @@ export default function LikeButton({ slug }: LikeButtonProps) {
   };
 
   return (
-    <div class="z-10 fixed bottom-4 right-4 flex flex-row items-center p-2 bg-white rounded-lg shadow-lg md:flex-col md:static md:p-0 md:bg-transparent md:shadow-none">
+    <div
+      class="z-10 fixed bottom-4 right-4 flex flex-row items-center p-2 bg-white rounded-lg shadow-lg md:flex-col md:static md:p-0 md:bg-transparent md:shadow-none"
+    >
       <button
         onClick={handleClick}
         class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${

--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -47,9 +47,7 @@ export default function LikeButton({ slug }: LikeButtonProps) {
   };
 
   return (
-    <div
-      class="z-10 fixed bottom-4 right-4 flex flex-row items-center p-2 bg-white rounded-lg shadow-lg md:flex-col md:static md:p-0 md:bg-transparent md:shadow-none"
-    >
+    <div class="flex flex-col items-center">
       <button
         onClick={handleClick}
         class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${
@@ -73,7 +71,7 @@ export default function LikeButton({ slug }: LikeButtonProps) {
           </path>
         </svg>
       </button>
-      <span class="ml-2 text-sm text-gray-500 md:mt-2 md:ml-0">{likeCount}</span>
+      <span class="mt-2 text-sm text-gray-500">{likeCount}</span>
     </div>
   );
 }

--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -47,7 +47,7 @@ export default function LikeButton({ slug }: LikeButtonProps) {
   };
 
   return (
-    <div class="flex flex-col items-center">
+    <div class="z-10 fixed bottom-4 right-4 flex flex-row items-center p-2 bg-white rounded-lg shadow-lg md:flex-col md:static md:p-0 md:bg-transparent md:shadow-none">
       <button
         onClick={handleClick}
         class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${
@@ -71,7 +71,7 @@ export default function LikeButton({ slug }: LikeButtonProps) {
           </path>
         </svg>
       </button>
-      <span class="mt-2 text-sm text-gray-500">{likeCount}</span>
+      <span class="ml-2 text-sm text-gray-500 md:mt-2 md:ml-0">{likeCount}</span>
     </div>
   );
 }

--- a/islands/LikeButton.tsx
+++ b/islands/LikeButton.tsx
@@ -3,9 +3,12 @@ import { useSignal } from "@preact/signals";
 
 interface LikeButtonProps {
   slug: string;
+  variant?: "default" | "footer";
 }
 
-export default function LikeButton({ slug }: LikeButtonProps) {
+export default function LikeButton(
+  { slug, variant = "default" }: LikeButtonProps,
+) {
   const likeCount = useSignal(0);
   const [isLiked, setIsLiked] = useState(false);
 
@@ -46,14 +49,22 @@ export default function LikeButton({ slug }: LikeButtonProps) {
     }
   };
 
+  const isFooter = variant === "footer";
+
   return (
-    <div class="flex flex-col items-center">
+    <div class={`flex items-center ${isFooter ? "flex-row" : "flex-col"}`}>
       <button
         onClick={handleClick}
-        class={`flex items-center justify-center w-12 h-12 rounded-full transition-colors duration-200 ${
-          isLiked
-            ? "bg-red-100 text-red-500"
-            : "bg-gray-100 text-gray-500 hover:bg-gray-200"
+        class={`flex items-center justify-center transition-colors duration-200 ${
+          isFooter
+            ? `p-2 ${
+              isLiked ? "text-red-500" : "text-gray-500 hover:text-gray-900"
+            }`
+            : `w-12 h-12 rounded-full ${
+              isLiked
+                ? "bg-red-100 text-red-500"
+                : "bg-gray-100 text-gray-500 hover:bg-gray-200"
+            }`
         }`}
         aria-label="Like this post"
       >
@@ -71,7 +82,9 @@ export default function LikeButton({ slug }: LikeButtonProps) {
           </path>
         </svg>
       </button>
-      <span class="mt-2 text-sm text-gray-500">{likeCount}</span>
+      <span class={`text-sm text-gray-500 ${isFooter ? "ml-1" : "mt-2"}`}>
+        {likeCount}
+      </span>
     </div>
   );
 }

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -31,8 +31,8 @@ export default function PostPage(props: PageProps<Post>) {
       </Head>
       <div class="flex-grow max-w-screen-lg mx-auto w-full">
         <div class="flex flex-row">
-          <div class="w-20 py-8">
-            <div class="sticky">
+          <div class="py-8 w-0 md:w-20">
+            <div class="sticky top-20">
               <LikeButton slug={post.slug} />
             </div>
           </div>

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -56,7 +56,7 @@ export default function PostPage(props: PageProps<Post>) {
         </div>
       </div>
       <div class="md:hidden fixed bottom-0 left-0 right-0 h-16 bg-white border-t border-gray-200 flex items-center justify-center">
-        <LikeButton slug={post.slug} />
+        <LikeButton slug={post.slug} variant="footer" />
       </div>
     </>
   );

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -31,7 +31,7 @@ export default function PostPage(props: PageProps<Post>) {
       </Head>
       <div class="flex-grow max-w-screen-lg mx-auto w-full">
         <div class="flex flex-row">
-          <div class="py-8 w-0 md:w-20">
+          <div class="hidden md:block w-20 py-8">
             <div class="sticky top-20">
               <LikeButton slug={post.slug} />
             </div>
@@ -54,6 +54,9 @@ export default function PostPage(props: PageProps<Post>) {
             />
           </main>
         </div>
+      </div>
+      <div class="md:hidden fixed bottom-0 left-0 right-0 h-16 bg-white border-t border-gray-200 flex items-center justify-center">
+        <LikeButton slug={post.slug} />
       </div>
     </>
   );


### PR DESCRIPTION
This change updates the Like button to be responsive. On mobile devices, the button is now fixed to the bottom-right of the screen for better accessibility and user experience, similar to the layout on dev.to. On desktop devices, the button retains its original position in the left sidebar.

The changes include:
- Modifying `islands/LikeButton.tsx` to apply responsive Tailwind CSS classes for positioning and layout.
- Adjusting `routes/entry/[...all].tsx` to hide the button's container on mobile, allowing the post content to span the full width of the screen.