### PR TITLE
feat: 記事詳細ページとトップページのマージンを調整

### DIFF
--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -29,7 +29,7 @@ export default function PostPage(props: PageProps<Post>) {
         />
         <style dangerouslySetInnerHTML={{ __html: CSS }} />
       </Head>
-      <div class="flex-grow max-w-screen-lg mx-auto w-full">
+      <div class="flex-grow max-w-screen-lg mx-auto w-full px-4 pt-4">
         <div class="flex flex-row">
           <div class="hidden md:block w-20 py-8">
             <div class="sticky top-20">

--- a/server.log
+++ b/server.log
@@ -1,0 +1,2 @@
+[0m[33mWarning[0m `"nodeModulesDir": true` is deprecated in Deno 2.0. Use `"nodeModulesDir": "auto"` instead.
+    at file:///app/deno.json


### PR DESCRIPTION
記事詳細ページのメインコンテナに `px-4 pt-4` クラスを追加し、トップページと共通のパディングを設定しました。

これにより、ページ間での一貫性が保たれ、特にモバイルデバイスでの閲覧体験が向上します。