### PR TITLE
chore(devcontainer): add Deno devcontainer, pin 1.45.x, and ignore .m…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,27 @@
 {
-	"name": "Deno Dev (win)",
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
-	"features": {
-		"ghcr.io/devcontainers/features/deno:1": {
-			"version": "1.46.x"
-		}
-	},
-	"postCreateCommand": "deno cache dev.ts",
-	"forwardPorts": [8000],
-	"portsAttributes": {
-		"8000": {
-			"label": "Fresh Dev Server",
-			"onAutoForward": "openBrowser"
-		}
-	},
-	"remoteUser": "vscode",
-	"customizations": {
-		"vscode": {
-			"extensions": ["denoland.vscode-deno"],
-			"settings": {
-				"deno.enable": true,
-				"deno.unstable": true
-			}
-		}
-	}
+  "name": "Deno Dev (win)",
+  "image": "mcr.microsoft.com/devcontainers/base:jammy",
+  "features": {
+    "ghcr.io/devcontainers/features/deno:1": {
+      "version": "1.45.x"
+    }
+  },
+  "postCreateCommand": "deno cache dev.ts",
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "8000": {
+      "label": "Fresh Dev Server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": ["denoland.vscode-deno"],
+      "settings": {
+        "deno.enable": true,
+        "deno.unstable": true
+      }
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "Deno Dev (win)",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/deno:1": {
+			"version": "1.46.x"
+		}
+	},
+	"postCreateCommand": "deno cache dev.ts",
+	"forwardPorts": [8000],
+	"portsAttributes": {
+		"8000": {
+			"label": "Fresh Dev Server",
+			"onAutoForward": "openBrowser"
+		}
+	},
+	"remoteUser": "vscode",
+	"customizations": {
+		"vscode": {
+			"extensions": ["denoland.vscode-deno"],
+			"settings": {
+				"deno.enable": true,
+				"deno.unstable": true
+			}
+		}
+	}
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: devcontainers
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 _fresh
+.mise.toml

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ deno task start
 This will watch the project directory and restart as necessary.
 
 [![Made with Fresh](https://fresh.deno.dev/fresh-badge.svg)](https://fresh.deno.dev)
+
+## Dev Container
+
+- Open the folder in VS Code and choose "Reopen in Container" (requires the Dev Containers extension).
+- The container includes Deno `1.45.x` (kept in sync with `.mise.toml`) and forwards port `8000`.
+- Once attached, run `deno task start` to launch the Fresh dev server.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This will watch the project directory and restart as necessary.
 
 ## Dev Container
 
-- Open the folder in VS Code and choose "Reopen in Container" (requires the Dev Containers extension).
-- The container includes Deno `1.45.x` (kept in sync with `.mise.toml`) and forwards port `8000`.
+- Open the folder in VS Code and choose "Reopen in Container" (requires the Dev
+  Containers extension).
+- The container includes Deno `1.45.x` (kept in sync with `.mise.toml`) and
+  forwards port `8000`.
 - Once attached, run `deno task start` to launch the Fresh dev server.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
-  "nodeModulesDir": true,
+  "nodeModulesDir": "auto",
   "tasks": {
     "start": "deno run -A --unstable-kv --watch=static/,routes/,islands/ dev.ts",
     "build": "deno run -A --unstable-kv dev.ts build",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": true,
   "tasks": {
     "start": "deno run -A --unstable-kv --watch=static/,routes/,islands/ dev.ts",
     "build": "deno run -A --unstable-kv dev.ts build",


### PR DESCRIPTION
…ise.toml

- Add .devcontainer with Deno feature (1.45.x)
- Enable Dependabot for devcontainers
- Ignore .mise.toml (local only)
- Update README with container usage