### PR TITLE
chore: Remove deprecated @9renpoto/textlint-config-ja package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "win",
   "private": true,
   "devDependencies": {
-    "@9renpoto/textlint-config-ja": "^7.9.0",
     "textlint": "^15.2.2",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-incremental-headers": "^0.2.0",


### PR DESCRIPTION
Removes the `@9renpoto/textlint-config-ja` package, which is deprecated and no longer supported.

A thorough investigation confirmed that this package was redundant. All textlint rules were already explicitly defined as dependencies in `package.json` and configured in `.textlintrc.json`.

The project's local `.textlintrc.json` contains a more specific and complete configuration than the one provided by the removed package. Therefore, no changes to `.textlintrc.json` were necessary.

This change resolves peer dependency conflicts caused by the outdated package and simplifies the project's dependencies.