### PR TITLE
feat: optimize OGP meta tags for X, Threads, and Bluesky

### DIFF
--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -1,14 +1,20 @@
-import { title as siteTitle } from "@/utils/website.ts";
+import { author as siteAuthor, title as siteTitle } from "@/utils/website.ts";
 
 export const SEO = ({
   title,
   description,
   ogImage,
+  ogUrl,
+  ogType = "website",
+  publishedAt,
   keywords,
 }: {
   title: string;
   description: string;
   ogImage: string;
+  ogUrl: string;
+  ogType?: "website" | "article";
+  publishedAt?: Date;
   keywords: string;
 }) => (
   <>
@@ -19,14 +25,25 @@ export const SEO = ({
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:image" content={ogImage} />
+    <meta property="og:url" content={ogUrl} />
     <meta property="og:site_name" content={siteTitle} />
-    <meta property="og:type" content="website" />
-    <meta property="og:locale" content="jp_JA" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="9renpoto" />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:locale" content="ja_JP" />
+    {ogType === "article" && publishedAt && (
+      <meta
+        property="article:published_time"
+        content={publishedAt.toISOString()}
+      />
+    )}
+    {ogType === "article" && (
+      <meta property="article:author" content={siteAuthor} />
+    )}
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@9renpoto" />
+    <meta name="twitter:creator" content="@9renpoto" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
-    <meta name="twitter:image:src" content={ogImage} />
+    <meta name="twitter:image" content={ogImage} />
     <meta name="keywords" content={keywords} />
   </>
 );

--- a/routes/about/index.tsx
+++ b/routes/about/index.tsx
@@ -3,7 +3,7 @@ import { page, type PageProps } from "fresh";
 import { Head } from "fresh/runtime";
 import { SEO } from "@/components/SEO.tsx";
 import { getPost, type Post } from "@/utils/posts.ts";
-import { description, title } from "@/utils/website.ts";
+import { description, siteUrl, title } from "@/utils/website.ts";
 
 export const handler: RouteHandler<Post, Record<string, never>> = {
   async GET(_ctx) {
@@ -22,6 +22,7 @@ export default function AboutPage(props: PageProps<Post>) {
           description={description}
           keywords={["life"].join(",")}
           ogImage="https://avatars3.githubusercontent.com/u/520693?s=460&v=4"
+          ogUrl={`${siteUrl}/about`}
         />
       </Head>
       <main class="flex-grow max-w-screen-lg w-full px-4 pt-4 mx-auto">

--- a/routes/entry/[...all].tsx
+++ b/routes/entry/[...all].tsx
@@ -1,11 +1,11 @@
+import type { RouteHandler } from "fresh";
 import { page, type PageProps } from "fresh";
 import { Head } from "fresh/runtime";
 import { SEO } from "@/components/SEO.tsx";
 import { TableOfContents } from "@/components/TableOfContents.tsx";
 import LikeButton from "@/islands/LikeButton.tsx";
 import { getPost, type Post } from "@/utils/posts.ts";
-import { description, title } from "@/utils/website.ts";
-import type { RouteHandler } from "fresh";
+import { description, siteUrl, title } from "@/utils/website.ts";
 
 export const handler: RouteHandler<Post, Record<string, never>> = {
   async GET(ctx) {
@@ -21,9 +21,12 @@ export default function PostPage(props: PageProps<Post>) {
       <Head>
         <SEO
           title={`${post.title} | ${title}`}
-          description={description}
+          description={post.snippet || description}
           keywords={["life"].join(",")}
           ogImage="https://avatars3.githubusercontent.com/u/520693?s=460&v=4"
+          ogUrl={`${siteUrl}/entry/${post.slug}`}
+          ogType="article"
+          publishedAt={post.publishedAt}
         />
       </Head>
       <div class="flex-grow max-w-screen-lg mx-auto w-full px-4 pt-4">

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -5,7 +5,7 @@ import { Bio } from "@/components/Bio.tsx";
 import { SEO } from "@/components/SEO.tsx";
 import PostList, { type PostItem } from "@/islands/PostList.tsx";
 import { getPosts } from "@/utils/posts.ts";
-import { author, description, title } from "@/utils/website.ts";
+import { author, description, siteUrl, title } from "@/utils/website.ts";
 
 const PAGE_SIZE = 10;
 
@@ -38,6 +38,7 @@ export default function BlogIndexPage({
           description={description}
           keywords={["life"].join(",")}
           ogImage="https://avatars3.githubusercontent.com/u/520693?s=460&v=4"
+          ogUrl={siteUrl}
         />
       </Head>
       <main class="max-w-screen-lg w-full px-4 pt-4 mx-auto">

--- a/utils/website.ts
+++ b/utils/website.ts
@@ -1,3 +1,4 @@
 export const title = ":-) 🏕";
 export const author = "Keisuke Umeno";
 export const description = "Have fun, Good luck";
+export const siteUrl = "https://9renpoto.win";


### PR DESCRIPTION
## Summary

Optimize OGP meta tags for X (Twitter), Threads, and Bluesky.

## Changes

### utils/website.ts
- Add `siteUrl` export

### components/SEO.tsx
- Fix `og:locale` from `jp_JA` to `ja_JP`
- Change `twitter:card` from `summary` to `summary_large_image`
- Rename `twitter:image:src` to standard `twitter:image`
- Add `@` prefix to `twitter:creator` and add `twitter:site`
- Add `og:url` prop
- Support `og:type` as `website` or `article`
- Output `article:published_time` and `article:author` for article pages

### Routes
- Pass canonical URL (`ogUrl`) to each page
- Add `ogType="article"` and `publishedAt` to entry pages
- Use `post.snippet` as description for article pages