### PR TITLE
RSSフィードに全文を含める改善

### DIFF
--- a/__tests__/routes/rss.test.ts
+++ b/__tests__/routes/rss.test.ts
@@ -13,7 +13,14 @@ Deno.test("rss handler returns valid RSS feed", async () => {
   assertEquals(response.status, 200);
   const body = await response.text();
   assertStringIncludes(body, "<rss xmlns:blogChannel=");
+  assertStringIncludes(
+    body,
+    'xmlns:content="http://purl.org/rss/1.0/modules/content/"',
+  );
   assertStringIncludes(body, "<channel>");
+  assertStringIncludes(body, "<content:encoded><![CDATA[");
+  assertStringIncludes(body, "]]></content:encoded>");
+  assertStringIncludes(body, "<language>ja</language>");
 });
 
 Deno.test("rss handler infers domain from request URL", async () => {

--- a/routes/rss.xml.ts
+++ b/routes/rss.xml.ts
@@ -23,22 +23,23 @@ export const handler: RouteHandler<Response, Record<string, never>> = {
     const allPosts = await getPosts();
 
     const rssString = `
-    <rss xmlns:blogChannel="${domainUrl}" version="2.0">
+    <rss xmlns:blogChannel="${domainUrl}" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
     <channel>
       <title>${title}</title>
       <link>${domainUrl}</link>
       <description>${title}</description>
-      <language>japanese</language>
+      <language>ja</language>
       <ttl>40</ttl>
       ${
       allPosts
-        .map(({ slug, publishedAt, snippet, title: postTitle }) =>
+        .map(({ slug, publishedAt, snippet, title: postTitle, html }) =>
           `
           <item>
             <title><![CDATA[${escapeCdata(postTitle)}]]></title>
             <description><![CDATA[${escapeHtml(snippet)}]]></description>
+            <content:encoded><![CDATA[${escapeCdata(html)}]]></content:encoded>
             <author><![CDATA[${escapeCdata(author)}]]></author>
-            <pubDate>${publishedAt}</pubDate>
+            <pubDate>${publishedAt.toUTCString()}</pubDate>
             <link>${domainUrl}/entry/${slug}</link>
             <guid>${domainUrl}/entry/${slug}</guid>
           </item>


### PR DESCRIPTION
RSSの内容を改善しました。
具体的には以下の変更を行いました：
- 各記事の全文を `<content:encoded>` に含めるようにしました
- RSS 2.0 の仕様に合わせ、名前空間 `xmlns:content` を追加しました
- 言語コードを `japanese` から `ja` に変更しました
- `pubDate` の形式を RFC 822 準拠の UTC 形式（`toUTCString()`）に変更しました
- 変更内容を検証するためのテストを追加・更新しました

---
*PR created automatically by Jules for task [11847951214041966265](https://jules.google.com/task/11847951214041966265) started by @9renpoto*