### PR TITLE
Add Deno and Dev Containers to Dependabot monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,35 @@ updates:
     directory: "/.devcontainer"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "deno"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "devcontainers"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,27 +16,3 @@ updates:
     directory: "/.devcontainer"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "deno"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "devcontainers"
-    directory: "/.devcontainer"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "deno"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "devcontainers"
-    directory: "/.devcontainer"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "deno"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "devcontainers"
-    directory: "/.devcontainer"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This pull request configures GitHub Dependabot to automatically track version updates for:
- Deno dependencies in `deno.json` at the root directory
- Dev Containers features in `.devcontainer/devcontainer.json`

Both ecosystems have been configured with a weekly schedule.

---
*PR created automatically by Jules for task [8803434779730300008](https://jules.google.com/task/8803434779730300008) started by @9renpoto*