### PR TITLE
chore(deps): bump marked from 12.0.2 to 18.0.7

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -57,7 +57,7 @@
     "autoprefixer": "npm:autoprefixer@^10.4.19",
     "fresh": "jsr:@fresh/core@^2.3.3",
     "linkedom": "npm:linkedom@^0.18.4",
-    "marked": "npm:marked@^12.0.2",
+    "marked": "npm:marked@^18.0.7",
     "preact": "npm:preact@^10.29.7",
     "preact-render-to-string": "npm:preact-render-to-string@^6.7.0",
     "tailwindcss": "npm:tailwindcss@^3.4.6",

--- a/utils/posts.ts
+++ b/utils/posts.ts
@@ -116,8 +116,10 @@ interface MarkedHeadingToken {
   raw: string;
   depth: number;
   text: string;
-  tokens: any[];
+  tokens: Token[];
 }
+
+import type { Token } from "marked";
 
 export async function renderMarkdown(
   content: string,
@@ -126,10 +128,10 @@ export async function renderMarkdown(
 ): Promise<string> {
   const renderer = new marked.Renderer();
   renderer.heading = function (
-    this: any,
+    this: { parser: { parseInline(tokens: Token[]): string } },
     { tokens, depth, text }: MarkedHeadingToken,
   ) {
-    const renderedText = this.parser.parseInline(tokens) as string;
+    const renderedText = this.parser.parseInline(tokens);
     const slug = slugifyHeading(text);
     headings.push({ level: depth, text: renderedText, slug });
     return `<h${depth} id="${slug}">${renderedText}</h${depth}>`;

--- a/utils/posts.ts
+++ b/utils/posts.ts
@@ -110,16 +110,29 @@ export function slugifyHeading(text: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+// Create a custom Heading type to represent the token parameter for heading in marked
+interface MarkedHeadingToken {
+  type: "heading";
+  raw: string;
+  depth: number;
+  text: string;
+  tokens: any[];
+}
+
 export async function renderMarkdown(
   content: string,
   headings: Heading[] = [],
   opts?: { skipEmbeds?: boolean },
 ): Promise<string> {
   const renderer = new marked.Renderer();
-  renderer.heading = (text: string, level: number, raw: string) => {
-    const slug = slugifyHeading(raw);
-    headings.push({ level, text, slug });
-    return `<h${level} id="${slug}">${text}</h${level}>`;
+  renderer.heading = function (
+    this: any,
+    { tokens, depth, text }: MarkedHeadingToken,
+  ) {
+    const renderedText = this.parser.parseInline(tokens) as string;
+    const slug = slugifyHeading(text);
+    headings.push({ level: depth, text: renderedText, slug });
+    return `<h${depth} id="${slug}">${renderedText}</h${depth}>`;
   };
 
   const html = marked.parse(content, { gfm: true, renderer }) as string;


### PR DESCRIPTION
This PR updates `marked` from version 12.0.2 to 18.0.7. It also fixes the custom heading renderer in `utils/posts.ts` to support the new object-based signature introduced in major upgrades. Tests and lint checks pass cleanly.

---
*PR created automatically by Jules for task [16485099184799440165](https://jules.google.com/task/16485099184799440165) started by @9renpoto*